### PR TITLE
调整 skywalking-oap 的 application.yml 适应 6.1 版本

### DIFF
--- a/docker-compose/devops/skywalking/config/application.yml
+++ b/docker-compose/devops/skywalking/config/application.yml
@@ -35,6 +35,9 @@ cluster:
 #    hostPort: ${SW_CLUSTER_CONSUL_HOST_PORT:localhost:8500}
 core:
   default:
+    # Mixed: Receive agent data, Level 1 aggregate, Level 2 aggregate
+    # Aggregator: Level 2 aggregate
+    role: ${SW_CORE_ROLE:Mixed} # Mixed/Receiver/Aggregator
     restHost: ${SW_CORE_REST_HOST:0.0.0.0}
     restPort: ${SW_CORE_REST_PORT:12800}
     restContextPath: ${SW_CORE_REST_CONTEXT_PATH:/}
@@ -61,10 +64,17 @@ storage:
     bulkSize: ${SW_STORAGE_ES_BULK_SIZE:20} # flush the bulk every 20mb
     flushInterval: ${SW_STORAGE_ES_FLUSH_INTERVAL:10} # flush the bulk every 10 seconds whatever the number of requests
     concurrentRequests: ${SW_STORAGE_ES_CONCURRENT_REQUESTS:2} # the number of concurrent requests
+    metadataQueryMaxSize: ${SW_STORAGE_ES_QUERY_MAX_SIZE:5000}
+    segmentQueryMaxSize: ${SW_STORAGE_ES_QUERY_SEGMENT_SIZE:200}
 #  h2:
 #    driver: ${SW_STORAGE_H2_DRIVER:org.h2.jdbcx.JdbcDataSource}
 #    url: ${SW_STORAGE_H2_URL:jdbc:h2:mem:skywalking-oap-db}
 #    user: ${SW_STORAGE_H2_USER:sa}
+#    metadataQueryMaxSize: ${SW_STORAGE_H2_QUERY_MAX_SIZE:5000}
+#  mysql:
+#    metadataQueryMaxSize: ${SW_STORAGE_H2_QUERY_MAX_SIZE:5000}
+receiver-sharing-server:
+  default:
 receiver-register:
   default:
 receiver-trace:
@@ -74,6 +84,7 @@ receiver-trace:
     bufferDataMaxFileSize: ${SW_RECEIVER_BUFFER_DATA_MAX_FILE_SIZE:500} # Unit is MB
     bufferFileCleanWhenRestart: ${SW_RECEIVER_BUFFER_FILE_CLEAN_WHEN_RESTART:false}
     sampleRate: ${SW_TRACE_SAMPLE_RATE:10000} # The sample rate precision is 1/10000. 10000 means 100% sample in default.
+    slowDBAccessThreshold: ${SW_SLOW_DB_THRESHOLD:default:200,mongodb:100} # The slow database access thresholds. Unit ms.
 receiver-jvm:
   default:
 service-mesh:
@@ -83,6 +94,8 @@ service-mesh:
     bufferDataMaxFileSize: ${SW_SERVICE_MESH_BUFFER_DATA_MAX_FILE_SIZE:500} # Unit is MB
     bufferFileCleanWhenRestart: ${SW_SERVICE_MESH_BUFFER_FILE_CLEAN_WHEN_RESTART:false}
 istio-telemetry:
+  default:
+envoy-metric:
   default:
 # receiver_zipkin:
 #   default:
@@ -94,3 +107,5 @@ query:
     path: ${SW_QUERY_GRAPHQL_PATH:/graphql}
 alarm:
   default:
+telemetry:
+  none:


### PR DESCRIPTION
skywalking-oap 是 6.1 版本，使用原配置会报错 ‘Exist cycle module dependencies in ...’，参照 6.1 源代码中的配置（./skywalking-6.1.0/docker/config）做修改。

参考：https://github.com/apache/skywalking/issues/2591