### PR TITLE
fix GatewayAdminApplication start warn

### DIFF
--- a/auth/authentication-server/src/main/java/com/springboot/cloud/auth/authentication/config/LoadResourceDefine.java
+++ b/auth/authentication-server/src/main/java/com/springboot/cloud/auth/authentication/config/LoadResourceDefine.java
@@ -7,6 +7,7 @@ import org.springframework.security.access.ConfigAttribute;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.PostConstruct;
 import java.util.Map;
 
 /**
@@ -18,8 +19,13 @@ class LoadResourceDefine {
     @Autowired
     private IResourceService resourceService;
 
-    @Bean
-    public Map<RequestMatcher, ConfigAttribute> resourceConfigAttributes() {
-        return resourceService.loadResource();
+    /**
+     *取消返回的bean防止外部出现线程安全问题
+     * 2020/5/15
+     * @return
+     */
+    @PostConstruct
+    public void resourceConfigAttributes() {
+        resourceService.loadResource();
     }
 }

--- a/auth/authentication-server/src/main/java/com/springboot/cloud/auth/authentication/provider/ResourceProviderFallback.java
+++ b/auth/authentication-server/src/main/java/com/springboot/cloud/auth/authentication/provider/ResourceProviderFallback.java
@@ -14,7 +14,7 @@ public class ResourceProviderFallback implements ResourceProvider {
     @Override
     public Result<Set<Resource>> resources() {
         log.error("认证服务启动时加载资源异常！未加载到资源");
-        return Result.success(new HashSet<Resource>());
+        return Result.fail();
     }
 
     @Override

--- a/auth/authentication-server/src/main/java/com/springboot/cloud/auth/authentication/service/IResourceService.java
+++ b/auth/authentication-server/src/main/java/com/springboot/cloud/auth/authentication/service/IResourceService.java
@@ -29,7 +29,7 @@ public interface IResourceService {
     /**
      * 加载权限资源数据
      */
-    Map<RequestMatcher, ConfigAttribute> loadResource();
+    void loadResource();
 
     /**
      * 根据url和method查询到对应的权限信息

--- a/auth/authentication-server/src/main/java/com/springboot/cloud/auth/authentication/service/impl/ResourceService.java
+++ b/auth/authentication-server/src/main/java/com/springboot/cloud/auth/authentication/service/impl/ResourceService.java
@@ -5,6 +5,7 @@ import com.alicp.jetcache.anno.Cached;
 import com.springboot.cloud.auth.authentication.provider.ResourceProvider;
 import com.springboot.cloud.auth.authentication.service.IResourceService;
 import com.springboot.cloud.auth.authentication.service.NewMvcRequestMatcher;
+import com.springboot.cloud.common.core.entity.vo.Result;
 import com.springboot.cloud.sysadmin.organization.entity.po.Resource;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -33,40 +35,44 @@ public class ResourceService implements IResourceService {
     /**
      * 系统中所有权限集合
      */
-    private Map<RequestMatcher, ConfigAttribute> resourceConfigAttributes;
+    private static final Map<RequestMatcher, ConfigAttribute> resourceConfigAttributes = new HashMap<>();
 
     @Override
-    public void saveResource(Resource resource) {
+    public synchronized void saveResource(Resource resource) {
         resourceConfigAttributes.put(
                 this.newMvcRequestMatcher(resource.getUrl(), resource.getMethod()),
                 new SecurityConfig(resource.getCode())
         );
-        log.info("resourceConfigAttributes size:{}", this.resourceConfigAttributes.size());
+        log.info("resourceConfigAttributes size:{}", resourceConfigAttributes.size());
     }
 
     @Override
-    public void removeResource(Resource resource) {
+    public synchronized void removeResource(Resource resource) {
         resourceConfigAttributes.remove(this.newMvcRequestMatcher(resource.getUrl(), resource.getMethod()));
-        log.info("resourceConfigAttributes size:{}", this.resourceConfigAttributes.size());
+        log.info("resourceConfigAttributes size:{}", resourceConfigAttributes.size());
     }
 
     @Override
-    public Map<RequestMatcher, ConfigAttribute> loadResource() {
-        Set<Resource> resources = resourceProvider.resources().getData();
-        this.resourceConfigAttributes = resources.stream()
+    public synchronized void loadResource() {
+        Result<Set<Resource>> resourcesResult = resourceProvider.resources();
+        if (resourcesResult.isFail()) {
+            System.exit(1);
+        }
+        Set<Resource> resources = resourcesResult.getData();
+        Map<MvcRequestMatcher, SecurityConfig> tempResourceConfigAttributes = resources.stream()
                 .collect(Collectors.toMap(
                         resource -> this.newMvcRequestMatcher(resource.getUrl(), resource.getMethod()),
                         resource -> new SecurityConfig(resource.getCode())
                 ));
-        log.debug("init resourceConfigAttributes:{}", this.resourceConfigAttributes);
-        return this.resourceConfigAttributes;
+        resourceConfigAttributes.putAll(tempResourceConfigAttributes);
+        log.debug("init resourceConfigAttributes:{}", resourceConfigAttributes);
     }
 
     @Override
     public ConfigAttribute findConfigAttributesByUrl(HttpServletRequest authRequest) {
-        return this.resourceConfigAttributes.keySet().stream()
+        return resourceConfigAttributes.keySet().stream()
                 .filter(requestMatcher -> requestMatcher.matches(authRequest))
-                .map(requestMatcher -> this.resourceConfigAttributes.get(requestMatcher))
+                .map(requestMatcher -> resourceConfigAttributes.get(requestMatcher))
                 .peek(urlConfigAttribute -> log.debug("url在资源池中配置：{}", urlConfigAttribute.getAttribute()))
                 .findFirst()
                 .orElse(new SecurityConfig("NONEXISTENT_URL"));

--- a/gateway/gateway-admin/src/main/java/com/springboot/cloud/gateway/admin/GatewayAdminApplication.java
+++ b/gateway/gateway-admin/src/main/java/com/springboot/cloud/gateway/admin/GatewayAdminApplication.java
@@ -6,8 +6,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.gateway.config.GatewayClassPathWarningAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = GatewayClassPathWarningAutoConfiguration.class)
 @EnableDiscoveryClient
 @EnableCircuitBreaker
 @EnableMethodCache(basePackages = "com.springboot.cloud")


### PR DESCRIPTION
原先的启动过程没有排除GatewayClassPathWarningAutoConfiguration 自动配置导致启动警告现在把GatewayClassPathWarningAutoConfiguration从自动配置中移除