### PR TITLE
perf:thin install command && update docker compose config

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -43,6 +43,7 @@ services:
 
   mysql-init:
     image: mysql:5.7
+    container_name: sc-mysql-init
     command: /init-db.sh
     networks:
       - sc-net
@@ -53,6 +54,8 @@ services:
       - ./init-db.sh:/init-db.sh
     environment:
       MYSQL_ROOT_PASSWORD: root123
+    depends_on:
+      - mysql
 
 networks:
   sc-net:

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ linux和mac下可在项目根目录下执行 `./install.sh` 快速搭建开发�
 
 2. 安装公共库到本地仓库： 
 
-`mvn -pl ./common,./auth/authentication-client install -DskipTests`
+`mvn -pl ./common,./auth/authentication-client install`
 
 3. 生成ide配置： `mvn idea:idea`或`mvn eclipse:eclipse` 并导入对应的ide进行开发，IDE安装lombok插件（很重要，否则IDE会显示编译报错）
 

--- a/readme.md
+++ b/readme.md
@@ -22,9 +22,7 @@ linux和mac下可在项目根目录下执行 `./install.sh` 快速搭建开发�
 
 2. 安装公共库到本地仓库： 
 
-`cd common && mvn install`
-
-`cd auth/authentication-client && mvn install`
+`mvn -pl ./common,./auth/authentication-client install -DskipTests`
 
 3. 生成ide配置： `mvn idea:idea`或`mvn eclipse:eclipse` 并导入对应的ide进行开发，IDE安装lombok插件（很重要，否则IDE会显示编译报错）
 


### PR DESCRIPTION
精简了安装命令，省去两次目录跳转，并且将两次打包命令合并为一次。

此外已经在`Windows`环境测试过可行，只需要将文件分隔符`/`换成`\`即可

优化了`docker-compose.yml`的配置，`mysql-init`要在`mysql`启动之后再执行脚本初始化行为