### PR TITLE
fix(sec): upgrade org.springframework:spring-web to 5.2.15.RELEASE

### DIFF
--- a/common/web/pom.xml
+++ b/common/web/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.springboot.cloud</groupId>
@@ -34,7 +33,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>5.0.4.RELEASE</version>
+            <version>5.2.15.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION
### What happened？
There are 6 security vulnerabilities found in org.springframework:spring-web 5.0.4.RELEASE
- [CVE-2020-5398](https://www.oscs1024.com/hd/CVE-2020-5398)
- [CVE-2020-5421](https://www.oscs1024.com/hd/CVE-2020-5421)
- [CVE-2021-22118](https://www.oscs1024.com/hd/CVE-2021-22118)
- [CVE-2018-15756](https://www.oscs1024.com/hd/CVE-2018-15756)
- [CVE-2018-11039](https://www.oscs1024.com/hd/CVE-2018-11039)
- [CVE-2018-11040](https://www.oscs1024.com/hd/CVE-2018-11040)


### What did I do？
Upgrade org.springframework:spring-web from 5.0.4.RELEASE to 5.2.15.RELEASE for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS